### PR TITLE
(fix) Fix patient queues dashboard links

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "start": "openmrs develop --backend https://ugandaemr-backend.mets.or.ug --sources 'packages/esm-*-app'",
+    "start": "openmrs develop",
     "ci:publish": "lerna publish from-package --yes",
     "ci:prepublish": "lerna publish from-package --no-git-reset --yes --dist-tag next",
     "release": "lerna version --no-git-tag-version",

--- a/packages/esm-patient-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-patient-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -31,8 +31,8 @@ const PatientQueueHeader: React.FC<{ title?: string }> = ({ title }) => {
         <div className={styles['left-justified-items']}>
           <PatientQueueIllustration />
           <div className={styles['page-labels']}>
-            <p>{t('queues', 'Patient Queues ')}</p>
-            <p className={styles['page-name']}>{title ?? t('serviceQueues', 'Service Queues')}</p>
+            <p>{t('queues', 'Patient queues ')}</p>
+            <p className={styles['page-name']}>{title ?? t('home', 'Home')}</p>
           </div>
         </div>
         <div className={styles['right-justified-items']}>

--- a/packages/esm-patient-queues-app/src/root.component.tsx
+++ b/packages/esm-patient-queues-app/src/root.component.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { SWRConfig } from 'swr';
-import ServicesTable from './queue-patient-linelists/queue-services-table.component';
-import AppointmentsTable from './queue-patient-linelists/scheduled-appointments-table.component';
+import Home from './home.component';
 
 const swrConfiguration = {
   errorRetryCount: 3,
@@ -12,10 +11,9 @@ const Root: React.FC = () => {
   return (
     <main>
       <SWRConfig value={swrConfiguration}>
-        <BrowserRouter basename={`${window.spaBase}/home/patient-queues`}>
+        <BrowserRouter basename={`${window.getOpenmrsSpaBase()}` + 'home/patient-queues'}>
           <Routes>
-            <Route path="/" element={<ServicesTable />} />
-            <Route path="/appointments-list/:value/" element={<AppointmentsTable />} />
+            <Route path="/" element={<Home />} />
           </Routes>
         </BrowserRouter>
       </SWRConfig>

--- a/packages/esm-patient-queues-app/src/routes.json
+++ b/packages/esm-patient-queues-app/src/routes.json
@@ -21,15 +21,15 @@
       "component": "patientQueuesDashboardLink",
       "slot": "homepage-dashboard-slot",
       "meta": {
-        "name": "patient-queues-dashboard-link",
+        "name": "patient-queues",
         "slot": "patient-queues-dashboard-slot",
-        "title": "Patient Queues"
+        "title": "Patient queues"
       }
     },
     {
-      "name": "queue-home-dashboard",
+      "name": "patient-queues",
       "slot": "patient-queues-dashboard-slot",
-      "component": "homeDashboard"
+      "component": "root"
     },
     {
       "name": "edit-queue-entry-status-modal",


### PR DESCRIPTION
This PR makes a few tweaks to the extensions and extension slot config of the Patient Queues app so that they render correctly in the home page.

## Screenshots

<img width="1800" alt="CleanShot 2023-08-26 at 4 58 47@2x" src="https://github.com/METS-Programme/esm-ugandaemr-core/assets/8509731/89b8b4b5-d8ea-4a06-b2ec-681782afebde">
