### PR TITLE
U4X-481 : In send to next queue allow user to see all locations of their parent including their own location

### DIFF
--- a/packages/esm-patient-queues-app/src/active-visits/change-status-move-to-next-dialog.component.tsx
+++ b/packages/esm-patient-queues-app/src/active-visits/change-status-move-to-next-dialog.component.tsx
@@ -120,7 +120,7 @@ const ChangeStatusMoveToNext: React.FC<ChangeStatusDialogProps> = ({ patientUuid
     }
   }, [contentSwitcherIndex]);
 
-  const filteredlocations = queueRoomLocations?.filter((location) => location.uuid != selectedLocation);
+  const filteredlocations = queueRoomLocations?.filter((location) => location.uuid != null);
 
   const filteredProviders = providers?.flatMap((provider) =>
     provider.attributes.filter(


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This PR removes filtered to locations exclusive of the current location

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->
https://metsprogramme.atlassian.net/browse/U4X-481

## Other
<!-- Anything not covered above -->
<!-- *None* -->
