### PR TITLE
U4X-490: Moving patients from triage to clinician seems to be using the same table (patient appears on both tables even before moving)

### DIFF
--- a/packages/esm-patient-queues-app/src/queue-clinical-room-home.component.tsx
+++ b/packages/esm-patient-queues-app/src/queue-clinical-room-home.component.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 
 import PatientQueueHeader from './patient-queue-header/patient-queue-header.component';
 import ActiveVisitsTabs from './active-visits/active-visits-tab.component';
+import { PRIVILEGE_CLINICIAN_QUEUE_LIST } from './constants';
+import { useSession, userHasAccess } from '@openmrs/esm-framework';
 
 const ClinicalRoomHome: React.FC = () => {
+  const session = useSession();
+
   return (
     <div>
       <PatientQueueHeader title="Clinical Room" />
-      <ActiveVisitsTabs />
+      {session?.user && userHasAccess(PRIVILEGE_CLINICIAN_QUEUE_LIST, session.user) && <ActiveVisitsTabs />}{' '}
     </div>
   );
 };

--- a/packages/esm-patient-queues-app/src/queue-reception-home.component.tsx
+++ b/packages/esm-patient-queues-app/src/queue-reception-home.component.tsx
@@ -9,9 +9,9 @@ import styles from './patient-queue-metrics/clinic-metrics.scss';
 import { useParentLocation } from './active-visits/patient-queues.resource';
 import { usePatientQueuesList } from './active-visit-patient-reception/active-visits-reception.resource';
 import { useAppointmentList, useServicePointCount } from './patient-queue-metrics/clinic-metrics.resource';
-import { UserHasAccess, useSession } from '@openmrs/esm-framework';
+import { UserHasAccess, useSession, userHasAccess } from '@openmrs/esm-framework';
 import QueueLauncher from './queue-launcher/queue-launcher.component';
-import { PRIVILEGE_RECEPTION_QUEUE_LIST } from './constants';
+import { PRIVILEGE_RECEPTION_METRIC, PRIVILEGE_RECEPTION_QUEUE_LIST } from './constants';
 
 const ReceptionHome: React.FC = () => {
   const { t } = useTranslation();
@@ -32,18 +32,19 @@ const ReceptionHome: React.FC = () => {
         <QueueLauncher />
       </UserHasAccess>
       <div className={styles.cardContainer}>
-        <MetricsCard
-          values={[{ label: 'Patients', value: pendingCount }]}
-          headerLabel={t('checkedInPatients', 'Checked in patients')}
-        />
-        <MetricsCard
-          values={[{ label: 'Expected Appointments', value: appointmentList?.length }]}
-          headerLabel={t('noOfExpectedAppointments', 'No. Of Expected Appointments')}
-        />
-        <MetricsCard values={stats} headerLabel={t('currentlyServing', 'No. of Currently being Served')} />
+        <UserHasAccess privilege={PRIVILEGE_RECEPTION_METRIC}>
+          <MetricsCard
+            values={[{ label: 'Patients', value: pendingCount }]}
+            headerLabel={t('checkedInPatients', 'Checked in patients')}
+          />
+          <MetricsCard
+            values={[{ label: 'Expected Appointments', value: appointmentList?.length }]}
+            headerLabel={t('noOfExpectedAppointments', 'No. Of Expected Appointments')}
+          />
+          <MetricsCard values={stats} headerLabel={t('currentlyServing', 'No. of Currently being Served')} />
+        </UserHasAccess>
       </div>
-
-      <ActiveVisitsReceptionTable />
+      {session?.user && userHasAccess(PRIVILEGE_RECEPTION_QUEUE_LIST, session.user) && <ActiveVisitsReceptionTable />}{' '}
     </div>
   );
 };

--- a/packages/esm-patient-queues-app/src/queue-triage-home.component.tsx
+++ b/packages/esm-patient-queues-app/src/queue-triage-home.component.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import PatientQueueHeader from './patient-queue-header/patient-queue-header.component';
 import MetricsCard from './patient-queue-metrics/metrics-card.component';
 import { useTranslation } from 'react-i18next';
-import { useSession } from '@openmrs/esm-framework';
+import { UserHasAccess, useSession, userHasAccess } from '@openmrs/esm-framework';
 import styles from './patient-queue-metrics/clinic-metrics.scss';
 
 import { useParentLocation } from './active-visits/patient-queues.resource';
 import { usePatientQueuesList } from './active-visit-patient-reception/active-visits-reception.resource';
 import { usePatientsBeingServed, usePatientsServed } from './patient-queue-metrics/clinic-metrics.resource';
 import ActiveVisitsTabs from './active-visits/active-visits-tab.component';
+import { PRIVILEGE_TRIAGE_QUEUE_LIST, PRIVILIGE_TRIAGE_METRIC } from './constants';
 
 const TriageHome: React.FC = () => {
   const { t } = useTranslation();
@@ -29,21 +30,23 @@ const TriageHome: React.FC = () => {
     <div>
       <PatientQueueHeader title="Triage" />
       <div className={styles.cardContainer}>
-        <MetricsCard
-          values={[{ label: 'In Queue', value: pendingCount }]}
-          headerLabel={t('inQueueTriage', 'Patients Waiting')}
-        />
-        <MetricsCard
-          values={[{ label: t('byTriage', 'By you'), value: patientQueueCount }]}
-          headerLabel={t('pendingTriageServing', 'Patients waiting to be Served')}
-        />
-        <MetricsCard
-          values={[{ label: 'Patients Served', value: servedCount }]}
-          headerLabel={t('noOfPatientsServed', 'No. of Patients Served')}
-        />
+        <UserHasAccess privilege={PRIVILIGE_TRIAGE_METRIC}>
+          <MetricsCard
+            values={[{ label: 'In Queue', value: pendingCount }]}
+            headerLabel={t('inQueueTriage', 'Patients Waiting')}
+          />
+          <MetricsCard
+            values={[{ label: t('byTriage', 'By you'), value: patientQueueCount }]}
+            headerLabel={t('pendingTriageServing', 'Patients waiting to be Served')}
+          />
+          <MetricsCard
+            values={[{ label: 'Patients Served', value: servedCount }]}
+            headerLabel={t('noOfPatientsServed', 'No. of Patients Served')}
+          />
+        </UserHasAccess>
       </div>
 
-      <ActiveVisitsTabs />
+      {session?.user && userHasAccess(PRIVILEGE_TRIAGE_QUEUE_LIST, session.user) && <ActiveVisitsTabs />}
     </div>
   );
 };


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This PR separates  the clinical room table from triage table

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->
https://metsprogramme.atlassian.net/browse/U4X-490

## Other
<!-- Anything not covered above -->
<!-- *None* -->
